### PR TITLE
More robust starting of Lustre, use Ansible functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ Requirements
 ------------
 
 Assumes you will build/obtain the module rpm's and place those to the given location beforehand.
-Tested with Ansible 1.9.4
+Tested with Ansible 1.9.4 and 2.0.2.
 
 
 Role Variables
 --------------
 ```
 lustre_lnet_networks: (default: none) -  what to put to /etc/modprobe.d/lustre.conf
-lustre_fstab_mount:   (default: none) - fstab line 
+lustre_mount_opts:    (default: _netdev,noatime,localflock,noauto) - Lustre mount options
+lustre_mount_src:     (default: none) - Lustre mount source
+lustre_mount_dir:     (default: none) - Path where Lustre will be mounted
 lustre_packages:      (default: none)
   - <package>
 
@@ -49,4 +51,4 @@ Version 2.0, January 2004
 Author Information
 ------------------
 https://github.com/mhakala
-
+https://github.com/jabl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for ansible-role-lustre_client
 lustre_client_enabled: False
 lustre_dir_mode: "0755"
+lustre_mount_opts: "_netdev,noatime,localflock,noauto"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,0 @@
----
-# handlers file for ansible-role-lustre_client
-
-- name: run_lustre_mount
-  command: mount {{ lustre_mount_dir }}

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,21 +10,25 @@
   template: src=lustre.conf.j2 dest=/etc/modprobe.d/lustre.conf
             owner=root group=root mode=0644
 
-- name: Add/modify lustre entry on /etc/fstab
-  lineinfile: dest=/etc/fstab regexp=" lustre " line="{{ lustre_fstab_mount }}" state=present
-  when: reg_lustre_test_grep.stdout != ""
+- name: Check Lustre networks
+  command: /usr/sbin/ip link show {{ item }}
+  with_items: "{{ lustre_network_devices }}"
+  register: lustre_networks
+  failed_when: False
+  changed_when: lustre_networks.rc != 0
+
+- name: Bring up Lustre networks if down
+  command: /usr/sbin/ifup {{ item[1] }}
+  when: item[0].rc != 0
+  with_nested:
+    - "{{ lustre_networks.results }}"
+    - "{{ lustre_network_devices }}"
+
+- name: Load Lustre modules
+  modprobe: name=lustre
 
 - name: create lustre mount directory
   file: "path={{ lustre_mount_dir }} state=directory mode={{ lustre_dir_mode }} owner=root group=root"
 
-- name: check lustre mount
-  command: grep -qs "{{ lustre_mount_dir }}" /proc/mounts
-  ignore_errors: yes
-  register: lustre_status
-
-- name: Bring up lustre network and mounts
-  command: /usr/sbin/ifup {{ item }}
-  with_items: "{{ lustre_network_devices }}"
-  when: lustre_status.rc != 0
-  notify: run_lustre_mount
-
+- name: Add Lustre entry to /etc/fstab, make sure it is mounted
+  mount: fstype=lustre name="{{ lustre_mount_dir }}" opts="{{ lustre_mount_opts }}" src="{{ lustre_mount_src }}" state=mounted


### PR DESCRIPTION
This patch makes use of the Ansible modprobe and mount modules to
load Lustre modules and add it to fstab. Also modifies checking and
bringing up the needed networks.
