### PR TITLE
ansible 2.2 updates to make role work if variables are undefined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@
 lustre_client_enabled: False
 lustre_dir_mode: "0755"
 lustre_mount_opts: "_netdev,noatime,localflock,noauto"
+lustre_packages: []
+#lustre_network_devices: []

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -16,6 +16,7 @@
   register: lustre_networks
   failed_when: False
   changed_when: lustre_networks.rc != 0
+  when: lustre_network_devices is defined
 
 - name: Bring up Lustre networks if down
   command: /usr/sbin/ifup {{ item[1] }}

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -19,7 +19,7 @@
 
 - name: Bring up Lustre networks if down
   command: /usr/sbin/ifup {{ item[1] }}
-  when: item[0].rc != 0
+  when: item[0].rc != 0 and (lustre_networks is defined and lustre_network_devices is defined)
   with_nested:
     - "{{ lustre_networks.results }}"
     - "{{ lustre_network_devices }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -12,18 +12,17 @@
 
 - name: Check Lustre networks
   command: /usr/sbin/ip link show {{ item }}
-  with_items: "{{ lustre_network_devices }}"
+  with_items: "{{ lustre_network_devices|default([]) }}"
   register: lustre_networks
   failed_when: False
   changed_when: lustre_networks.rc != 0
-  when: lustre_network_devices is defined
 
 - name: Bring up Lustre networks if down
   command: /usr/sbin/ifup {{ item[1] }}
-  when: item[0].rc != 0 and (lustre_networks is defined and lustre_network_devices is defined)
+  when: item[0].rc != 0
   with_nested:
     - "{{ lustre_networks.results }}"
-    - "{{ lustre_network_devices }}"
+    - "{{ lustre_network_devices|default([]) }}"
 
 - name: Load Lustre modules
   modprobe: name=lustre


### PR DESCRIPTION
 - we set lustre_packages to [] by default - this task won't do anything if that is empty
 - skip checking or bringing up interfaces if the registered variable is not defined or the lustre_network_devices is not defined