### PR TITLE
Add Lustre Lnet multi-rail support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ lustre_dir_mode: "0755"
 lustre_mount_opts: "_netdev,noatime,localflock,noauto"
 lustre_packages: []
 #lustre_network_devices: []
+lustre_network_ib_partitions: False
+lustre_lnet_multi_rail: False

--- a/files/add-ips.awk
+++ b/files/add-ips.awk
@@ -1,0 +1,18 @@
+# Add extra IPS to interface (to be used for Lustre Lnet multi-rail)
+BEGIN {
+    FS="=";
+}
+{
+    if ($1 == "IPADDR") {
+        split($2, ips, ".")
+        printf "IPADDR0=%s\n", $2
+        printf "IPADDR1=%s.%s.%s.%s\n", ips[1], ips[2] + 1, ips[3], ips[4]
+        printf "IPADDR2=%s.%s.%s.%s\n", ips[1], ips[2] + 2, ips[3], ips[4]
+    }
+    else if ($1 == "NETMASK") {
+        printf "NETMASK0=%s\nNETMASK1=%s\nNETMASK2=%s\n", $2, $2, $2
+    }
+    else {
+        printf "%s=%s\n", $1, $2
+    }
+}

--- a/tasks/ohpc.yml
+++ b/tasks/ohpc.yml
@@ -8,11 +8,35 @@
     mode: 0744
     owner: root
     group: root
+  when: lustre_network_ib_partitions|bool
 
 - name: Run the script from rc.local
   lineinfile:
     path: /etc/rc.d/rc.local
     line: '/usr/local/sbin/ifcfg-ibpart-create.sh'
+  when: lustre_network_ib_partitions|bool
+
+- name: Add extra IPs for Lnet multi-rail
+  copy:
+    src: add-ips.awk
+    dest: /usr/local/sbin/add-ips.awk
+    mode: 0644
+    owner: root
+    group: root
+  when: lustre_lnet_multi_rail|bool
+
+- name: Run multi-rail setup from rc.local
+  blockinfile:
+    path: /etc/rc.d/rc.local
+    block: |
+      tf=$(mktemp tmp.XXXXX)
+      awk -f /usr/local/sbin/add-ips.awk /etc/sysconfig/network-scripts/ifcfg-{{ lustre_network_devices[0] }} > ${tf}
+      mv ${tf} /etc/sysconfig/network-scripts/ifcfg-{{ lustre_network_devices[0] }}
+      ifdown {{ lustre_network_devices[0] }}
+      ifup {{ lustre_network_devices[0] }}
+      modprobe lustre
+      mount {{ lustre_mount_dir }}
+  when: lustre_lnet_multi_rail|bool
 
 - name: Make sure rc.local is executable
   file:


### PR DESCRIPTION
When using Lustre Lnet multi-rail the recommended configuration is to
use a separate subnet for each interface on the Lustre servers. Thus
add scripts to add those to the clients. For the time being this only
works with clients having a single interface.