### PR TITLE
Use alias interfaces for multi-rail

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,4 @@ lustre_mount_opts: "_netdev,noatime,localflock,noauto"
 lustre_packages: []
 #lustre_network_devices: []
 lustre_network_ib_partitions: False
-lustre_lnet_multi_rail: False
+lustre_network_ib_aliases: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,5 @@ lustre_mount_opts: "_netdev,noatime,localflock,noauto"
 lustre_packages: []
 #lustre_network_devices: []
 lustre_network_ib_partitions: False
-lustre_network_ib_aliases: False
+# To use network aliases, set to e.g.
+# lustre_network_ib_aliases: "2 3"

--- a/tasks/ohpc.yml
+++ b/tasks/ohpc.yml
@@ -16,20 +16,20 @@
     line: '/usr/local/sbin/ifcfg-ibpart-create.sh'
   when: lustre_network_ib_partitions|bool
 
-- name: Add extra IPs for Lnet multi-rail
+- name: Add network device alias script for Lnet multi-rail
   copy:
     src: ifcfg-create-alias.sh
     dest: /usr/local/sbin/ifcfg-create-alias.sh
     mode: 0744
     owner: root
     group: root
-  when: lustre_network_ib_aliases|bool
+  when: lustre_network_ib_aliases is defined
 
-- name: Run multi-rail setup from rc.local
+- name: Run multi-rail network device alias script from rc.local
   lineinfile:
     path: /etc/rc.d/rc.local
-    line: '/usr/local/sbin/ifcfg-create-alias.sh'
-  when: lustre_network_ib_aliases|bool
+    line: "/usr/local/sbin/ifcfg-create-alias.sh {{ lustre_network_devices[0] }} {{ lustre_network_ib_aliases }}"
+  when: lustre_network_ib_aliases is defined
 
 - name: Make sure rc.local is executable
   file:

--- a/tasks/ohpc.yml
+++ b/tasks/ohpc.yml
@@ -18,25 +18,18 @@
 
 - name: Add extra IPs for Lnet multi-rail
   copy:
-    src: add-ips.awk
-    dest: /usr/local/sbin/add-ips.awk
-    mode: 0644
+    src: ifcfg-create-alias.sh
+    dest: /usr/local/sbin/ifcfg-create-alias.sh
+    mode: 0744
     owner: root
     group: root
-  when: lustre_lnet_multi_rail|bool
+  when: lustre_network_ib_aliases|bool
 
 - name: Run multi-rail setup from rc.local
-  blockinfile:
+  lineinfile:
     path: /etc/rc.d/rc.local
-    block: |
-      tf=$(mktemp tmp.XXXXX)
-      awk -f /usr/local/sbin/add-ips.awk /etc/sysconfig/network-scripts/ifcfg-{{ lustre_network_devices[0] }} > ${tf}
-      mv ${tf} /etc/sysconfig/network-scripts/ifcfg-{{ lustre_network_devices[0] }}
-      ifdown {{ lustre_network_devices[0] }}
-      ifup {{ lustre_network_devices[0] }}
-      modprobe lustre
-      mount {{ lustre_mount_dir }}
-  when: lustre_lnet_multi_rail|bool
+    line: '/usr/local/sbin/ifcfg-create-alias.sh'
+  when: lustre_network_ib_aliases|bool
 
 - name: Make sure rc.local is executable
   file:


### PR DESCRIPTION
Turns out that having multiple IP's for a single interface doesn't
propely work for Lustre. Thus instead use alias interfaces
(eg. ib0:1).