### PR TITLE
Alter single to double quotes on module options

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -33,5 +33,5 @@ def test_lustre_mounts(host):
 def test_lustre_module_options(host):
     modfile = '/etc/modprobe.d/lustre.conf'
     assert host.file(modfile).contains(
-        r"networks='tcp2(eth0)' routes='my route' auto_down=1"
+        r'networks="tcp2(eth0)" routes="my route" auto_down="1"'
     )

--- a/templates/lustre.conf.j2
+++ b/templates/lustre.conf.j2
@@ -1,7 +1,7 @@
 {% if lustre_modprobe_options is defined %}
 options lnet
 {%- for key, value in lustre_modprobe_options.items() %}
- {{ key }}={{ value | quote }}
+ {{ key }}="{{ value }}"
 {%- endfor -%}
 {% elif  lustre_lnet_networks is defined %}
 options lnet networks="{{ lustre_lnet_networks }}"


### PR DESCRIPTION
Seems like modprobe doesn't like single quotes around options

This commit wrap all options with double quotes