### PR TITLE
Use lustre_mounts' state if given, to enable removing old mounts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ lustre_mount_state: "{{ 'mounted' if ansible_connection != 'chroot' else 'presen
 #  - { path:, src:, opts: [] }
 #  - { path: "/default",  src: "/opts" }
 #  - { path: "/my",  src: "/opts",  opts: ['my_opt'] }
+#  - { path: "/old", src: "10.2.20.10@o2ib:/lustre", state: "absent"
 #  - { path: "/merge",  src: "/opts",  opts: "{{ lustre_mount_opts + ['my_opt'] }}" }
 
 # Comment to not add repository

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -64,6 +64,6 @@
     path: "{{ item.path }}"
     src: "{{ item.src }}"
     opts: "{{ item.opts | default(lustre_mount_opts) | join(',') }}"
-    state: "{{ lustre_mount_state }}"
+    state: "{{ item.state | default(lustre_mount_state) }}"
   loop: "{{ lustre_mounts }}"
   when: lustre_mounts is defined


### PR DESCRIPTION
Just modified to use lustre_mounts' state if given, otherwise we'll default to the previous lustre_mount_state from defaults.yml